### PR TITLE
Stop using biplist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ test:	localbuild
 pyflakes:
 	pyflakes $(PY_FILES_DIRS) 2>&1 | \
           grep -v "local variable 'dummy' is assigned to but never used" | \
-          grep -v -E "'(biplist|setuptools|win32com|find_executable|parse_sitemap|parse_sitemapindex|parse_bookmark_data|parse_bookmark_file|wsgiref|pyftpdlib|linkchecker_rc)' imported but unused" | \
+          grep -v -E "'(setuptools|win32com|find_executable|parse_sitemap|parse_sitemapindex|parse_bookmark_data|parse_bookmark_file|wsgiref|pyftpdlib|linkchecker_rc)' imported but unused" | \
           grep -v "undefined name '_'" | \
 	  grep -v "undefined name '_n'" | cat
 

--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -16,6 +16,7 @@ Changes:
 - checking: login forms with only one field are supported
 - checking: slack and whatsapp added to the list of ignored schemes
 - tests: Test coverage has been increased
+- biplist is no longer used because plistlib now supports binary files
 - dnspython and miniboa are no longer included
 - Custom MANIFEST check replaced with check-manifest
 - Code now passes flake8 checks

--- a/linkcheck/bookmarks/safari.py
+++ b/linkcheck/bookmarks/safari.py
@@ -14,21 +14,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-import sys
-
 import plistlib
-
-try:
-    import biplist
-
-    has_biplist = True
-except ImportError:
-    has_biplist = False
-
-if sys.version_info >= (3, 9):
-    # Although the biplist module imports on Python 3.9 it is not compatible:
-    # https://bitbucket.org/wooster/biplist/issues/12
-    has_biplist = False
 
 
 def parse_bookmark_data(data):
@@ -39,15 +25,11 @@ def parse_bookmark_data(data):
 
 
 def get_plist_data_from_string(data):
-    """Parse plist data for a string. Tries biplist, falling back to
-    plistlib."""
-    if has_biplist:
-        return biplist.readPlistFromString(data)
-    # fall back to normal plistlist
+    """Parse plist data for a string."""
     try:
         return plistlib.loads(data)
     except Exception:
-        # not parseable (eg. not well-formed, or binary)
+        # not parseable (eg. not well-formed)
         return {}
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -22,7 +22,6 @@ import pytest
 from contextlib import contextmanager
 from functools import lru_cache, wraps
 from linkcheck import LinkCheckerInterrupt
-from linkcheck.bookmarks.safari import has_biplist as bookmarks_has_biplist
 
 
 basedir = os.path.dirname(__file__)
@@ -169,15 +168,6 @@ def has_pyftpdlib():
 
 
 need_pyftpdlib = _need_func(has_pyftpdlib, "pyftpdlib")
-
-
-@lru_cache(1)
-def has_biplist():
-    """Test if biplist is available."""
-    return bookmarks_has_biplist
-
-
-need_biplist = _need_func(has_biplist, "biplist")
 
 
 @lru_cache(1)

--- a/tests/checker/test_bookmarks.py
+++ b/tests/checker/test_bookmarks.py
@@ -17,7 +17,7 @@
 Test bookmark file parsing.
 """
 from . import LinkCheckTest
-from .. import need_network, need_biplist
+from .. import need_network
 import os
 
 
@@ -47,7 +47,6 @@ class TestBookmarks(LinkCheckTest):
         self.file_test(os.path.join("plist_xml", "Bookmarks.plist"))
 
     @need_network
-    @need_biplist
     def test_safari_bookmarks_binary(self):
         # Safari bookmark file parsing (for binary plist files)
         self.file_test(os.path.join("plist_binary", "Bookmarks.plist"))

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,6 @@ deps =
     pytest-xdist
     pytest-cov
     miniboa >= 1.0.8
-    biplist
     GeoIP
 
 [testenv]


### PR DESCRIPTION
plistlib has supported binary files since Python 3.4.